### PR TITLE
Fixed exclusion of empty strings in ABS

### DIFF
--- a/JAVA/src/it/bancaditalia/oss/sdmx/client/custom/ABS.java
+++ b/JAVA/src/it/bancaditalia/oss/sdmx/client/custom/ABS.java
@@ -79,7 +79,7 @@ public class ABS extends DotStat{
 
 	// https://github.com/amattioc/SDMX/issues/19
 	private static String fixWildcard(String resource) {
-		String[] items = resource.split("\\.");
+		String[] items = resource.split("\\.", -1);
 		if (items.length <= 1) {
 			return resource;
 		}


### PR DESCRIPTION
An annoying behavior of String.split(String) excludes empty strings. We must use String.split(String, int) instead.
See http://docs.oracle.com/javase/6/docs/api/java/lang/String.html#split(java.lang.String, int)