### PR TITLE
Retrieve codelists and concepts with data structure

### DIFF
--- a/JAVA/src/it/bancaditalia/oss/sdmx/client/RestSdmxClient.java
+++ b/JAVA/src/it/bancaditalia/oss/sdmx/client/RestSdmxClient.java
@@ -356,7 +356,7 @@ public class RestSdmxClient implements GenericSDMXClient{
 				dsd!=null && !dsd.isEmpty()){
 
 			String query = RestQueryBuilder.getStructureQuery(endpoint, dsd, agency,  version);
-			return query;
+			return query + "?references=children";
 		}
 		else{
 			throw new RuntimeException("Invalid query parameters: agency=" + agency + " dsd=" + dsd + " endpoint=" + endpoint);


### PR DESCRIPTION
According to this documentation (http://sdw-wsrest.ecb.europa.eu/documentation/index.jsp#metadata), some metadata are not retrieved with a data structure if not asked explicitly when dealing with a SDMX 2.1 RESTful web service.

Codelists and concepts are only included if you add "references=children" at the end of the query.

This seems to defer from SDMX 2.0 where those metadata are included by default.