### PR TITLE
Added properties to configure builtin providers

### DIFF
--- a/JAVA/configuration.properties
+++ b/JAVA/configuration.properties
@@ -16,12 +16,24 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 #### Network configuration
 #http.proxy.default = hostname:port
 #http.proxy.name0 = hostname:port
-#http.proxy.name0.urls = sdw-ws.ecb.europa.eu,stats.oecd.org,sdmx.istat.it,sdmxws.imf.org,ec.europa.eu,www.ilo.org,sdw-wsrest.ecb.europa.eu,www.snieg.mx,stat.abs.gov.au 
+#http.proxy.name0.urls = sdw-ws.ecb.europa.eu,stats.oecd.org,sdmx.istat.it,sdmxws.imf.org,ec.europa.eu,www.ilo.org,sdw-wsrest.ecb.europa.eu,www.snieg.mx,stat.abs.gov.au
 
-#http.auth.preference = Kerberos  
-#java.security.krb5.conf = 
-#java.security.auth.login.config = 
+#http.auth.preference = Kerberos
+#java.security.krb5.conf =
+#java.security.auth.login.config =
 
 #http.auth.preference = basic
-#http.auth.user = 
-#http.auth.pw 
+#http.auth.user =
+#http.auth.pw
+
+### Providers settings
+# Sdmx Connectors comes with appropriate defaults for the builtin providers.
+# If you need to overwrite the defaults, the properties below can be used.
+# Please replace PROVIDER_ID with the id of the provider you wish to change (e.g. ECB, ISTAT, OECD, etc.).
+
+# providers.PROVIDER_ID.name = YOUR_NAME
+# providers.PROVIDER_ID.endpoint = YOUR_ENDPOINT
+# providers.PROVIDER_ID.needsCredentials = false
+# providers.PROVIDER_ID.needsURLEncoding = false
+# providers.PROVIDER_ID.supportsCompression = true
+# providers.PROVIDER_ID.description = YOUR_DESCRIPTION

--- a/JAVA/test/it/bancaditalia/oss/sdmx/client/SdmxClientFactoryTest.java
+++ b/JAVA/test/it/bancaditalia/oss/sdmx/client/SdmxClientFactoryTest.java
@@ -1,0 +1,46 @@
+/* Copyright 2010,2014 Bank Of Italy
+*
+* Licensed under the EUPL, Version 1.1 or - as soon they
+* will be approved by the European Commission - subsequent
+* versions of the EUPL (the "Licence");
+* You may not use this work except in compliance with the
+* Licence.
+* You may obtain a copy of the Licence at:
+*
+*
+* http://ec.europa.eu/idabc/eupl
+*
+* Unless required by applicable law or agreed to in
+* writing, software distributed under the Licence is
+* distributed on an "AS IS" basis,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied.
+* See the Licence for the specific language governing
+* permissions and limitations under the Licence.
+*/
+package it.bancaditalia.oss.sdmx.client;
+
+import java.util.Map;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class SdmxClientFactoryTest {
+
+    @Test
+    public void getProviders() {
+        final Map<String, Provider> providers = SDMXClientFactory.getProviders();
+        assertFalse(providers.isEmpty());
+
+        final Provider ecb = providers.get("ECB");
+        assertNotNull(ecb);
+        assertEquals("ECB", ecb.getName());
+        assertEquals("http://sdw-wsrest.ecb.europa.eu/service", ecb.getEndpoint().toString());
+        assertFalse(ecb.isNeedsCredentials());
+        assertFalse(ecb.isNeedsURLEncoding());
+        assertTrue(ecb.isSupportsCompression());
+        assertEquals("European Central Bank", ecb.getDescription());
+    }
+}


### PR DESCRIPTION
As discussed, a proposal to configure builtin providers via configuration.properties.

Fix #71 