### PR TITLE
Initialize cause of SdmxExceptions

### DIFF
--- a/JAVA/src/it/bancaditalia/oss/sdmx/client/RestSdmxClient.java
+++ b/JAVA/src/it/bancaditalia/oss/sdmx/client/RestSdmxClient.java
@@ -110,7 +110,7 @@ public class RestSdmxClient implements GenericSDMXClient{
 		} catch (Exception e) {
 			logger.severe("Exception caught parsing results from call to provider " + name);
 			logger.log(Level.FINER, "Exception: ", e);
-			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage());
+			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage(), e);
 		} finally{
 			if(xmlStream != null){
 				try {
@@ -141,7 +141,7 @@ public class RestSdmxClient implements GenericSDMXClient{
 		} catch (Exception e) {
 			logger.severe("Exception caught parsing results from call to provider " + name);
 			logger.log(Level.FINER, "Exception: ", e);
-			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage());
+			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage(), e);
 		} finally{
 			if(xmlStream != null){
 				try {
@@ -168,7 +168,7 @@ public class RestSdmxClient implements GenericSDMXClient{
 			catch (Exception e) {
 				logger.severe("Exception caught parsing results from call to provider " + name);
 				logger.log(Level.FINER, "Exception: ", e);
-				throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage());
+				throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage(), e);
 			} finally{
 				if(xmlStream != null){
 					try {
@@ -199,7 +199,7 @@ public class RestSdmxClient implements GenericSDMXClient{
 		} catch (Exception e) {
 			logger.severe("Exception caught parsing results from call to provider " + name);
 			logger.log(Level.FINER, "Exception: ", e);
-			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage());
+			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage(), e);
 		} finally{
 			if(xmlStream != null){
 				try {
@@ -237,7 +237,7 @@ public class RestSdmxClient implements GenericSDMXClient{
 		} catch (Exception e) {
 			logger.severe("Exception caught parsing results from call to provider " + name);
 			logger.log(Level.FINER, "Exception: ", e);
-			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage());
+			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage(), e);
 		} finally{
 			if(xmlStream != null){
 				try {

--- a/JAVA/src/it/bancaditalia/oss/sdmx/client/custom/RestSdmx20Client.java
+++ b/JAVA/src/it/bancaditalia/oss/sdmx/client/custom/RestSdmx20Client.java
@@ -105,7 +105,7 @@ public abstract class RestSdmx20Client extends RestSdmxClient{
 		} catch (Exception e) {
 			logger.severe("Exception caught parsing results from call to provider " + name);
 			logger.log(Level.FINER, "Exception: ", e);
-			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage());
+			throw new SdmxException("Exception. Class: " + e.getClass().getName() + " .Message: " + e.getMessage(), e);
 		} finally{
 			try {
 				xmlStream.close();

--- a/JAVA/src/it/bancaditalia/oss/sdmx/util/SdmxException.java
+++ b/JAVA/src/it/bancaditalia/oss/sdmx/util/SdmxException.java
@@ -26,9 +26,12 @@ public class SdmxException extends Exception{
 		super(message);
 	}
 
+	public SdmxException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
-
 }


### PR DESCRIPTION
This pull request adds a second constructor for SdmxException that also accepts a Throwable cause.

The purpose of this pull request is to allow programmatic diagnostics of the caught exceptions, such as:
* Was my query bad?
* Was it caused by an internet outage?
* Did the SDMX parser try to parse a bad XML response?

As it is now, users/developers have to read the message to discern the reason of the exception. That's fine for development purposes. However, I'm currently trying to skip over bad XML responses from OECD on some data flows/time series, but making sure my application breaks down if anything else goes wrong. In this case, I need to be able to discern the Exceptions programmatically, specifically to check if the cause of the exception is javax.xml.stream.XMLStreamException, which is only available in the message.