### PR TITLE
Add event listener in RestSdmxClient.

### DIFF
--- a/JAVA/src/it/bancaditalia/oss/sdmx/client/RestSdmxEventListener.java
+++ b/JAVA/src/it/bancaditalia/oss/sdmx/client/RestSdmxEventListener.java
@@ -1,0 +1,19 @@
+package it.bancaditalia.oss.sdmx.client;
+
+import it.bancaditalia.oss.sdmx.api.Message;
+import java.net.URL;
+
+/**
+ *
+ * @author Philippe Charles
+ */
+public class RestSdmxEventListener {
+
+	public static final RestSdmxEventListener NO_OP = new RestSdmxEventListener();
+	
+	public void onDataFooterMessage(URL query, Message msg) {
+	}
+
+	public void onRedirection(URL oldURL, URL newURL) {
+	}
+}


### PR DESCRIPTION
The purpose of this listener is to programmatically uncover dubious behaviours from remote servers such as:
- unexpected footer message in data response
- redirection from https to http protocol