### PR TITLE
Fixed mapping of dataflows in RestSdmxClient.

### DIFF
--- a/JAVA/src/main/java/it/bancaditalia/oss/sdmx/client/RestSdmxClient.java
+++ b/JAVA/src/main/java/it/bancaditalia/oss/sdmx/client/RestSdmxClient.java
@@ -170,7 +170,7 @@ public class RestSdmxClient implements GenericSDMXClient
 		{
 			result = new HashMap<>();
 			for (Dataflow dataflow : flows)
-				result.put(dataflow.getId(), dataflow);
+				result.put(dataflow.getFullIdentifier(), dataflow);
 		}
 		else
 		{


### PR DESCRIPTION
The return type of `RestSdmxClient#getDataflows()` is a `Map<String, Dataflow>` built by `Dataflow#getId`. This leads to conflics when two dataflows share the same id but have different versions.
Thus, the map should be built by `Dataflow#getFullIdentifier()`.

Here is an example of this problem :
https://sdmxcentral.imf.org/ws/public/sdmxapi/rest/dataflow/all/all/latest/ 
The dataflow `NAMAIN_IDC_N` has two versions: `1.0` and `1.9`.