### PR TITLE
Fix JDK11 compilation

### DIFF
--- a/JAVA/pom.xml
+++ b/JAVA/pom.xml
@@ -60,6 +60,22 @@
 	</properties>
 
 	<profiles>
+		<!-- Fix missing Java EE Modules in JDK11 -->
+		<profile>
+			<id>fix-missing-modules-jdk11</id>
+			<activation>
+				<jdk>[11,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>javax.xml.bind</groupId>
+					<artifactId>jaxb-api</artifactId>
+					<version>2.4.0-b180830.0359</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+            
 		<profile>
 			<id>compile-stata</id>
 			<activation>

--- a/JAVA/src/main/java/it/bancaditalia/oss/sdmx/helper/CheckboxListTableModel.java
+++ b/JAVA/src/main/java/it/bancaditalia/oss/sdmx/helper/CheckboxListTableModel.java
@@ -62,7 +62,7 @@ public class CheckboxListTableModel<T> extends DefaultTableModel
 	{
 		List<String> codes = new LinkedList<>();
 
-		for (Vector<?> row : (Vector<Vector<?>>) getDataVector())
+		for (Vector row : (Vector<Vector>) getDataVector())
 			// 0 => checkbox column
 			if ((Boolean) row.get(0))
 				// 1 => key column


### PR DESCRIPTION
Connectors depends on JAXB API to compute base64 for basic auth.
This API has been removed from JDK11. Here is a tweak to fix it.

Note that while it compiles, it still fails at runtime if JAXB API is not available on classpath.
