### PR TITLE
Enforce use of https on EUROSTAT

### DIFF
--- a/JAVA/src/main/java/it/bancaditalia/oss/sdmx/client/custom/EUROSTAT.java
+++ b/JAVA/src/main/java/it/bancaditalia/oss/sdmx/client/custom/EUROSTAT.java
@@ -46,7 +46,7 @@ import it.bancaditalia.oss.sdmx.util.Configuration;
  *
  */
 public class EUROSTAT extends RestSdmxClient{
-	private static final String EUROSTAT_PROVIDER = "http://ec.europa.eu/eurostat/SDMX/diss-web/rest";
+	private static final String EUROSTAT_PROVIDER = "https://ec.europa.eu/eurostat/SDMX/diss-web/rest";
 	private int sleepTime = 6000;
 	private int retries = Integer.parseInt(Configuration.getLateResponseRetries(10));
 	


### PR DESCRIPTION
It is now possible to query Eurostat REST web service through https.