### PR TITLE
Workaround when proxy returns HTTP_PROXY_AUTH code

### DIFF
--- a/JAVA/src/main/java/it/bancaditalia/oss/sdmx/client/RestSdmxClient.java
+++ b/JAVA/src/main/java/it/bancaditalia/oss/sdmx/client/RestSdmxClient.java
@@ -400,7 +400,19 @@ public class RestSdmxClient implements GenericSDMXClient
 				}
 
 				code = conn instanceof HttpURLConnection ? ((HttpURLConnection) conn).getResponseCode() : HttpURLConnection.HTTP_OK;
+				if (code == HttpURLConnection.HTTP_PROXY_AUTH)
+				{
+					LOGGER.fine("Error with proxy. Second attempt after forcing acces to http website in first place.");
+					URI uritest= new URI("http://google.com");
+					URL urltest = uritest.toURL();
+					conn = urltest.openConnection(proxy);
+					((HttpURLConnection) conn).setRequestMethod("GET");
+					code = conn instanceof HttpURLConnection ? ((HttpURLConnection) conn).getResponseCode() : HttpURLConnection.HTTP_OK;
+					conn = url.openConnection(proxy);
+					((HttpURLConnection) conn).setRequestMethod("GET");
+					code = conn instanceof HttpURLConnection ? ((HttpURLConnection) conn).getResponseCode() : HttpURLConnection.HTTP_OK;
 
+				}
 				if (isRedirection(code))
 				{
 					URL redirection = getRedirectionURL(conn, code);


### PR DESCRIPTION
Force first to connect to http (google.com) and do a second attempt to connect to the original URL. HTTP_PROXY_AUTH code might be returned when the app tries to connect to https but might work if it has connected first to a http website.